### PR TITLE
[feat]type.jsの実装

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -11,7 +11,8 @@
         "next": "14.2.4",
         "react": "^18",
         "react-dom": "^18",
-        "sass": "^1.77.5"
+        "sass": "^1.77.5",
+        "typed.js": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4770,6 +4771,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed.js/-/typed.js-2.1.0.tgz",
+      "integrity": "sha512-bDuXEf7YcaKN4g08NMTUM6G90XU25CK3bh6U0THC/Mod/QPKlEt9g/EjvbYB8x2Qwr2p6J6I3NrsoYaVnY6wsQ==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.4.5",

--- a/next/package.json
+++ b/next/package.json
@@ -13,7 +13,8 @@
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
-    "sass": "^1.77.5"
+    "sass": "^1.77.5",
+    "typed.js": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/next/src/app/_components/TypingEffect/index.tsx
+++ b/next/src/app/_components/TypingEffect/index.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import React, { useEffect, useRef } from 'react';
+import Typed from 'typed.js';
+
+const TypingEffect: React.FC = () => {
+  const textRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (textRef.current) {
+      const options = {
+        strings: ['Hello World!', 'Welcome to Typed.js!'],
+        typeSpeed: 50,
+        backSpeed: 25,
+        loop: true,
+        showCursor: true,
+        cursorChar: '|',
+      };
+
+      const typed = new Typed(textRef.current, options);
+
+      return () => {
+        typed.destroy();
+      };
+    }
+  }, []);
+
+  return (
+    <div id="app" style={{ textAlign: 'center', marginTop: '50px' }}>
+      <span id="typed" ref={textRef}></span>
+    </div>
+  );
+};
+
+export default TypingEffect;

--- a/next/src/app/page.tsx
+++ b/next/src/app/page.tsx
@@ -1,11 +1,12 @@
 import Image from "next/image";
 import styles from "./page.module.scss";
+import TypingEffect from './_components/TypingEffect'
 
 export default function Home() {
   return (
     <main>
       <p className={styles.title}>aaa</p>
-      
+      <TypingEffect />
     </main>
   );
 }


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
# 対応 Issue
- resolve #5 


<!-- 開発内容の概要を記載 -->
# 概要
iTyped.jsを実装予定だったが、うまく導入できなかったためTyped.jsを導入した。
Typed.jsの機能を確認し、導入を行った。
<!-- 具体的な開発内容を記載 -->
# 実装内容
①5-iTyped-installのブランチの作成
- ` git branch`でブランチの一覧表示
- ` git checkout -b feat/mtureit/5-iTyped-install`
- 
②Typed.jsの導入
- Git Bashを用いて`npm install typed.js`を打つ
- `npm run dev`でlocalhost:3000を立ち上げる

③Typed.jsを用いたサンプルプロジェクトを作成
- `src/app`にファイル名`_components/TypingEffect`を作成
- Typed.jsの機能を試す`index.module.scss`、`index.tsx`の作成
- `index.module.scss`を以下のように記述
```
"use client"

import React, { useEffect, useRef } from 'react';
import Typed from 'typed.js';
import styles from './index.module.scss'

const TypingEffect: React.FC = () => {
  const textRef = useRef<HTMLSpanElement>(null);

  useEffect(() => {
    if (textRef.current) {
      const options = {
        strings: ['Hello World!', 'Welcome to Typed.js!'],
        typeSpeed: 50,
        backSpeed: 25,
        loop: true,
        showCursor: true,
        cursorChar: '|',
      };

      const typed = new Typed(textRef.current, options);

      return () => {
        typed.destroy();
      };
    }
  }, []);

  return (
    <div id="app" style={{ textAlign: 'center', marginTop: '50px' }}>
      <span id="typed" ref={textRef}></span>
    </div>
  );
};

export default TypingEffect;
```
- `index.tsx`を以下のように記述
```
"use client"

import React, { useEffect, useRef } from 'react';
import Typed from 'typed.js';
import styles from './index.module.scss'

const TypingEffect: React.FC = () => {
  const textRef = useRef<HTMLSpanElement>(null);

  useEffect(() => {
    if (textRef.current) {
      const options = {
        strings: ['Hello World!', 'Welcome to Typed.js!'],
        typeSpeed: 50,
        backSpeed: 25,
        loop: true,
        showCursor: true,
        cursorChar: '|',
      };

      const typed = new Typed(textRef.current, options);

      return () => {
        typed.destroy();
      };
    }
  }, []);

  return (
    <div id="app" style={{ textAlign: 'center', marginTop: '50px' }}>
      <span id="typed" ref={textRef}></span>
    </div>
  );
};

export default TypingEffect;
```
- localhost:3000にアクセスする
- `cd next`でnextを開く
- `npm install` → `npm run dev`で実行

<!-- URLとともに貼る（なければ空欄でよい） -->
# 画面スクリーンショット等
- localhost:3000にアクセスした画面
![Typed-jsの導入](https://github.com/mtureit/eita-portfolio/assets/52872293/f6e238a8-853e-47ee-9d47-47ee5f32bbea)

<!-- テストしてほしい内容を記載 -->
# テスト項目
- [x] localhost:3000にアクセスするとTyped.jsを用いたページが表示される。

# 備考