### PR TITLE
 [feat] font-apply (#14)

### DIFF
--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -1,22 +1,26 @@
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from 'next'
+import { DotGothic16 } from 'next/font/google'
+import './globals.css'
 
-const inter = Inter({ subsets: ["latin"] });
+const dotgothic16 = DotGothic16({
+  weight: '400',
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
-  title: "EITA-PORTFOLIO",
-  description: "松浦瑛太のポートフォリオサイト",
-};
+  title: 'EITA-PORTFOLIO',
+  description: '松浦瑛太のポートフォリオサイト',
+}
 
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
 }>) {
   return (
     <html lang="ja">
-      <body className={inter.className}>{children}</body>
+      <body className={dotgothic16.className}>{children}</body>
     </html>
-  );
+  )
 }


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
# 対応 Issue
- resolve #14 


<!-- 開発内容の概要を記載 -->
# 概要
- DotGothic16のフォント設定

<!-- 具体的な開発内容を記載 -->
# 実装内容
layout.tsxの内容を以下のように書き換えた。
```
import type { Metadata } from 'next'
import { DotGothic16 } from 'next/font/google'
import './globals.css'

const dotgothic16 = DotGothic16({
  weight: '400',
  subsets: ['latin'],
  display: 'swap',
})

export const metadata: Metadata = {
  title: 'EITA-PORTFOLIO',
  description: '松浦瑛太のポートフォリオサイト',
}

export default function RootLayout({
  children,
}: Readonly<{
  children: React.ReactNode
}>) {
  return (
    <html lang="ja">
      <body className={dotgothic16.className}>{children}</body>
    </html>
  )
}

```

<!-- URLとともに貼る（なければ空欄でよい） -->
# 画面スクリーンショット等


<!-- テストしてほしい内容を記載 -->
# テスト項目
- [ ] localhost:3000にアクセスすると DotGothic16のフォント設定が確認できる


# 備考
参考サイト:[https://nextjs.org/docs/app/building-your-application/optimizing/fonts](url)