### PR TITLE
 [feat] Skillsの作成(#12)

### DIFF
--- a/next/src/app/_components/Skills/index.module.scss
+++ b/next/src/app/_components/Skills/index.module.scss
@@ -1,0 +1,102 @@
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  flex-direction: column;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  letter-spacing: 0.2em;
+  line-height: 0.5; /* 行の高さを調整する */
+  width: 100%;
+  h2 {
+    margin: 0px;
+    margin-bottom: 32px;
+    padding: 0;
+    font-size: 48px;
+  }
+  .component {
+    justify-content: center;
+    max-width: 1440px;
+    font-size: 32px;
+    width: 70%;
+  }
+  .box {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 56px;
+  }
+  .status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .about {
+    font-size: 32px;
+    text-align: center;
+    margin: 0px;
+  }
+  .detail {
+    display: flex;
+    align-items: center; /* 横並びにするために追加 */
+    border: 6px solid #fff;
+    border-radius: 10px;
+    text-align: left;
+    letter-spacing: 0.3em;
+    flex-direction: row; /* 子要素を横方向に配置 */
+    width: 100%;
+  }
+
+  .icon {
+    margin-right: 16px; /* アイコンとテキストの間にスペースを追加 */
+    font-size: 80px;
+    align-self: flex-start; /* アイコンを上端に配置 */
+  }
+}
+/*メディアクエリ*/
+/*タブレット*/
+@media screen and (max-width: 1000px) {
+  .container .component {
+    display: block;
+    flex-direction: column;
+    width: 90%;
+    h2 {
+      font-size: 40px;
+      margin-bottom: 24px;
+    }
+  }
+  .container .box {
+    gap: 24px;
+  }
+
+  .status .detail {
+    border: 4px solid #fff;
+  }
+}
+
+/*スマホ*/
+@media (max-width: 600px) {
+  .container .component {
+    display: block;
+    flex-direction: column;
+    width: 95%;
+  }
+  .container h2 {
+    font-size: 24px;
+    margin-bottom: 16px;
+  }
+  .container .box {
+    display: block;
+    font-size: 16px;
+  }
+  .status .about {
+    font-size: 16px;
+  }
+  .status .detail {
+    border: 2px solid #fff;
+  }
+  .status .icon {
+    font-size: 40px;
+  }
+}

--- a/next/src/app/_components/Skills/index.tsx
+++ b/next/src/app/_components/Skills/index.tsx
@@ -1,12 +1,56 @@
 'use client'
 
+import s from './index.module.scss'
 import React from 'react'
+import { RxTriangleRight } from 'react-icons/rx'
 
 const Skills: React.FC = () => {
   return (
-    <>
-      <p>Skills</p>
-    </>
+    <section className={s.container}>
+      <h2>Skills</h2>
+      <div className={s.component}>
+        <div className={s.box}>
+          <div className={s.status}>
+            <div className={s.about}>
+              <p>front</p>
+            </div>
+            <div className={s.detail}>
+              <div className={s.icon}>
+                <RxTriangleRight />
+              </div>
+              <div>
+                <p>HTML</p>
+                <p>CSS</p>
+                <p>TypeScript</p>
+                <p>React</p>
+                <p>Next.js</p>
+              </div>
+            </div>
+          </div>
+          <div className={s.status}>
+            <div className={s.about}>
+              <p>back</p>
+            </div>
+            <div className={s.detail}>
+              <div className={s.icon}>
+                <RxTriangleRight />
+              </div>
+              <div>
+                <p>Unity</p>
+                <p>C#</p>
+                <p>Java</p>
+                <br></br>
+                <br></br>
+                <br></br>
+                <br></br>
+                <br></br>
+                <br></br>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   )
 }
 


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
# 対応 Issue
- resolve #12 
<!-- 開発内容の概要を記載 -->
# 概要
- ポートフォリオにおけるSkillsの作成
- gitのコマンドの一つgit stashの機能確認

<!-- 具体的な開発内容を記載 -->
# 実装内容
１.Skillsのindex.tsxの内容を書き換えた
- frontとbackのカードは同じクラス名を記述し管理した。
- back側のカードの大きさをfrontと同じにするため改行タグを使用したが、もしかしたらもっといい方法があるかも...

2.Skillsのindex.module.scssの内容を書き換えた
- 入れ子構造での記述は予想外の動作を引き起こすため記述しない。
- カード内で三角形と文字を横方向に配置するのには`flex-direction: row; `が便利
- レスポンシブによって変わるwidthは他のcomponentと同様の調整を行った。
- **PC画面にした場合全画面表示にしても余白の部分が大きく、水平方向のスクロールバーが表示される。
　→ max-widthが原因...?　バグ修正はのちのちfixにて行う**
<!-- URLとともに貼る（なければ空欄でよい） -->
# 画面スクリーンショット等
PC画面
![スクリーンショット 2024-07-03 232600](https://github.com/mtureit/eita-portfolio/assets/52872293/7180d950-aced-4def-a288-2d3a3ab1a11c)

タブレット画面
![スクリーンショット 2024-07-03 232729](https://github.com/mtureit/eita-portfolio/assets/52872293/6d9feaa0-4d4d-440e-bb1e-8e72511603ec)

スマホ画面
![スクリーンショット 2024-07-03 232744](https://github.com/mtureit/eita-portfolio/assets/52872293/8382dc43-d58b-421d-aea8-0081aa47b898)

<!-- テストしてほしい内容を記載 -->
# テスト項目
- [ ] PC画面においてlocalhost:3000にアクセスするとSkillsの実装が確認できる
- [ ] タブレット画面においてlocalhost:3000にアクセスするとSkillsの実装が確認できる
- [ ] スマホ画面においてlocalhost:3000にアクセスするとSkillsの実装が確認できる

# 備考
SkillsのbranchはProductionのプルリクが承認される前に作成しました。
Skillsのbranchはstashコマンドを用いて一時的に保存しました。
その後、Productionの修正を行いProductionのマージを行いました。
マージを行った後stashコマンドで保存していたSkillsの変更内容を呼び出してissueに対応しました。